### PR TITLE
Hotfix: Remove stray arg

### DIFF
--- a/staged-dependencies.R
+++ b/staged-dependencies.R
@@ -103,7 +103,6 @@ if (file.exists("staged_dependencies.yaml")) {
     install_project = FALSE,
     verbose = 1,
     install_external_deps = TRUE,
-    dependencies = TRUE,
     upgrade = "never",
     Ncpus = threads
   )


### PR DESCRIPTION
Keyword args in `staged.dependencies::install_deps` specified options to pass to `remotes::install_github`
One of those options is `dependencies`, which results in a conflict. 
