### PR TITLE
Bugfix: Reload remotes after installation

### DIFF
--- a/system-dependencies.R
+++ b/system-dependencies.R
@@ -15,7 +15,9 @@ if (!require("remotes")) {
   )
 }
 # Upgrade the remotes package to get the latest bugfixes
-remotes::install_github("r-lib/remotes")
+remotes::install_github("r-lib/remotes@main")
+# Load remotes
+library(remotes)
 
 os_info <- read.csv("/etc/os-release", sep = "=", header = FALSE)
 v_os_info <- setNames(os_info$V2, os_info$V1)


### PR DESCRIPTION
Otherwise the previously loaded version takes effect due to namespace persistence.