### PR TITLE
Replace remotes installation via remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The following options are available are available for this action:
 
 * `quiet`:
 
-  _Description_: If TRUE, suppress output
+  _Description_: Reduce logging
 
   _Required_: `false`
 
@@ -190,7 +190,7 @@ The following options are available are available for this action:
 
 * `upgrade-remotes`:
 
-    _Description_: If TRUE, upgrades the 'remotes' R package to the edge version
+    _Description_: Upgrades the 'remotes' R package to the edge version
 
     _Required_: `false`
 

--- a/action.yml
+++ b/action.yml
@@ -53,11 +53,11 @@ inputs:
     required: false
     default: true
   quiet:
-    description: If TRUE, suppress output
+    description: Reduce logging
     required: false
     default: true
   upgrade-remotes:
-    description: If TRUE, upgrades the 'remotes' R package to the edge version
+    description: Upgrades the 'remotes' R package to the edge version
     required: false
     default: false
   direction:

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,7 @@ runs:
       shell: bash
       env:
         SD_REPO_PATH: "${{ inputs.path }}"
+        SD_QUIET: "${{ inputs.quiet }}"
         SD_UPGRADE_REMOTES: "${{ inputs.upgrade-remotes }}"
 
     - name: Run staged dependencies

--- a/staged-dependencies.R
+++ b/staged-dependencies.R
@@ -74,15 +74,19 @@ if (!require("remotes", quietly = sd_quiet) && upgrade_remotes != "true") {
 
 # Upgrade the remotes package to get the latest bugfixes
 if (upgrade_remotes == "true") {
+  print("Upgrading the remotes package to get the latest version from GitHub")
   old_wd <- getwd()
   tmp_dir <- tempdir()
   setwd(tmp_dir)
+  print("Downloading the remotes package source")
   download.file(
     url = "https://github.com/r-lib/remotes/archive/refs/heads/main.zip",
     dest = "remotes.zip"
   )
+  print("Extracting the remotes package source")
   unzip("remotes.zip")
   file.rename("remotes-main", "remotes")
+  print("Building the remotes package from source")
   system2(
     command = "R",
     args = c(
@@ -91,6 +95,7 @@ if (upgrade_remotes == "true") {
       "remotes"
     )
   )
+  print("Installing the remotes package")
   system2(
     command = "R",
     args = c(

--- a/staged-dependencies.R
+++ b/staged-dependencies.R
@@ -64,7 +64,7 @@ if (threads == "auto") {
 }
 
 # Install the remotes package
-if (!require("remotes", quietly = sd_quiet)) {
+if (!require("remotes", quietly = sd_quiet) && upgrade_remotes != "true") {
   install.packages(
     "remotes",
     upgrade = "never",
@@ -73,12 +73,33 @@ if (!require("remotes", quietly = sd_quiet)) {
 }
 
 # Upgrade the remotes package to get the latest bugfixes
-## TODO: Install directly from GitHub repository instead of
-## using remotes. To precent the "Inception" effect
 if (upgrade_remotes == "true") {
-  remotes::install_github("r-lib/remotes@main")
-  # Reload remotes
-  require(remotes)
+  old_wd <- getwd()
+  tmp_dir <- tempdir()
+  setwd(tmp_dir)
+  download.file(
+    url = "https://github.com/r-lib/remotes/archive/refs/heads/main.zip",
+    dest = "remotes.zip"
+  )
+  unzip("remotes.zip")
+  file.rename("remotes-main", "remotes")
+  system2(
+    command = "R",
+    args = c(
+      "CMD", "build",
+      "--no-manual", "--no-build-vignettes", "--force",
+      "remotes"
+    )
+  )
+  system2(
+    command = "R",
+    args = c(
+      "CMD", "INSTALL",
+      "--no-docs",
+      "remotes_*.tar.gz"
+    )
+  )
+  setwd(old_wd)
 }
 
 options(

--- a/staged-dependencies.R
+++ b/staged-dependencies.R
@@ -73,6 +73,8 @@ if (!require("remotes", quietly = sd_quiet)) {
 }
 
 # Upgrade the remotes package to get the latest bugfixes
+## TODO: Install directly from GitHub repository instead of
+## using remotes. To precent the "Inception" effect
 if (upgrade_remotes == "true") {
   remotes::install_github("r-lib/remotes@main")
   # Reload remotes

--- a/system-dependencies.R
+++ b/system-dependencies.R
@@ -2,10 +2,13 @@
 
 repo_path <- Sys.getenv("SD_REPO_PATH", ".")
 upgrade_remotes <- Sys.getenv("SD_UPGRADE_REMOTES", "")
+sd_quiet <- isTRUE(as.logical(Sys.getenv("SD_QUIET", "true")))
 
 cat("\n==================================\n")
 cat("Running system dependencies installer\n")
 cat(paste("repo_path: \"", repo_path, "\"\n", sep = ""))
+cat(paste("sd_quiet: \"", sd_quiet, "\"\n", sep = ""))
+cat(paste("upgrade_remotes: \"", upgrade_remotes, "\"\n", sep = ""))
 cat("==================================\n")
 
 # Install the remotes package

--- a/system-dependencies.R
+++ b/system-dependencies.R
@@ -61,6 +61,11 @@ v_os_info <- setNames(os_info$V2, os_info$V1)
 if (v_os_info[["NAME"]] == "Ubuntu") {
   ubuntu_version <- as.character(v_os_info[["VERSION_ID"]])
   cat(paste("Ubuntu version: \"", ubuntu_version, "\"\n", sep = ""))
+  # The following is a workaround until we have a newer
+  # version of remotes that supports Ubuntu 22.04
+  if (ubuntu_version == "22.04") {
+    ubuntu_version <- "20.04"
+  }
   sys_deps_for_pkg <- remotes::system_requirements(
     os = "ubuntu",
     os_release = ubuntu_version,

--- a/system-dependencies.R
+++ b/system-dependencies.R
@@ -9,18 +9,47 @@ cat(paste("repo_path: \"", repo_path, "\"\n", sep = ""))
 cat("==================================\n")
 
 # Install the remotes package
-if (!require("remotes")) {
+if (!require("remotes", quietly = sd_quiet) && upgrade_remotes != "true") {
   install.packages(
     "remotes",
-    repos = "https://cloud.r-project.org/"
+    upgrade = "never",
+    Ncpus = threads
   )
 }
 
 # Upgrade the remotes package to get the latest bugfixes
 if (upgrade_remotes == "true") {
-  remotes::install_github("r-lib/remotes@main")
-  # Reload remotes
-  require(remotes)
+  print("Upgrading the remotes package to get the latest version from GitHub")
+  old_wd <- getwd()
+  tmp_dir <- tempdir()
+  setwd(tmp_dir)
+  print("Downloading the remotes package source")
+  download.file(
+    url = "https://github.com/r-lib/remotes/archive/refs/heads/main.zip",
+    dest = "remotes.zip"
+  )
+  print("Extracting the remotes package source")
+  unzip("remotes.zip")
+  file.rename("remotes-main", "remotes")
+  print("Building the remotes package from source")
+  system2(
+    command = "R",
+    args = c(
+      "CMD", "build",
+      "--no-manual", "--no-build-vignettes", "--force",
+      "remotes"
+    )
+  )
+  print("Installing the remotes package")
+  system2(
+    command = "R",
+    args = c(
+      "CMD", "INSTALL",
+      "--no-docs",
+      "remotes_*.tar.gz"
+    )
+  )
+  setwd(old_wd)
 }
 
 os_info <- read.csv("/etc/os-release", sep = "=", header = FALSE)


### PR DESCRIPTION
This is being done in order to avoid package DB corruption which occurs when remotes is used to install itself, since it is loaded into the namespace.